### PR TITLE
fix: add hasEditableBoundaries property for workshop metadata

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -185,6 +185,10 @@ async function createMetaJson(
     newMeta = getBaseMeta('FullStack');
     newMeta.blockType = blockType;
     newMeta.blockLayout = blockLayout;
+    // Add hasEditableBoundaries for workshops
+    if (blockType === 'workshop') {
+      newMeta.hasEditableBoundaries = true;
+    }
   } else {
     newMeta = getBaseMeta('Step');
     newMeta.order = order;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62411

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR fixes the missing `hasEditableBoundaries` property in workshop metadata files generated by the `create-new-project` script.

## Changes Made

- Added conditional logic in `create-project.ts` to include `hasEditableBoundaries: true` specifically for workshop block types
- The property is only added when `blockType === 'workshop'`, ensuring other project types remain unchanged
- Tested the fix by creating a test workshop and verifying the metadata includes the required property

## Problem Fixed

When creating new workshop projects using the `create-new-project` script, the generated metadata file was missing the `hasEditableBoundaries: true` property, which is required for workshops to function properly with the multifile editor.

## Testing

- Ran the `create-new-project` script to create a test workshop
- Verified the generated metadata correctly includes `hasEditableBoundaries: true`
- Confirmed other project types are not affected by this change